### PR TITLE
Error on single update/patch

### DIFF
--- a/yummie
+++ b/yummie
@@ -158,7 +158,7 @@ class Yummie(object):
                         part[1],          # package version
                     ))
 
-        return len(self.updates)
+        return returncode
 
     def excluded(self, name):
         for exclude in self.exclude:


### PR DESCRIPTION
We ran into a bug where if there is only one update, yummie thinks there was a error.

I tracked down the error to the return being len(self.updates) instead of returning the "returncode."
Which looks to be the actual thing your trying to check further down.

Tested the changes and they look to be working.




```
284     if updates == 0:                                                           
285         logging.info('No updates')                                             
286         return 0                                                               
287                                                                                
288     elif updates == 1:                                                         
289         logging.error('Checking for updates failed:')                          
290         for line in yummie.errors.splitlines():                                
291             logging.error(line.rstrip())                                       
292         return 1                                                               
293                                                                                
294     if yummie.updates:                                                         
295         logging.info('%d packages need updating:' % len(yummie.updates))       
296         for update, version in sorted(yummie.updates):                         
297             logging.debug('    %s %s' % (update, version))                     
298                                                                                
299     else:                                                                      
300         logging.info('System up to date')                                      
301         return 0                                           
```